### PR TITLE
i18n: add Arabic translations

### DIFF
--- a/i18n/ar.toml
+++ b/i18n/ar.toml
@@ -1,0 +1,5 @@
+[pagination_next]
+other = "التالي"
+
+[pagination_prev]
+other = "السابق"


### PR DESCRIPTION
## Summary

- add Arabic translations for the next and previous pagination labels

## Why

Arabic sites currently fall back to English for these controls.

## Validation

- rendered both keys with Hugo 0.146.5
- built with `--printI18nWarnings`; no warnings for the added keys

The repository's existing lint command currently stops because ESLint 10 cannot find a configuration file.
